### PR TITLE
Using YYYY-MM-DD for dates in the sales report

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Sample config:
   "key_file": "./AuthKey_AAAAAAAAA.p8",
   "issuer_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
   "vendor": "3333333",
-  "start_date": "2019-02-01T00:00:00Z"
+  "start_date": "2019-02-01T00:00:00Z",
+  "convert_dates": false
 }
 ```

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-appstore',
-      version='0.2.1-airbyte',
+      version='0.2.1.1',
       description='Singer.io tap for extracting data from the App Store Connect API',
       author='JustEdro',
       url='https://github.com/JustEdro',

--- a/tap_appstore/__init__.py
+++ b/tap_appstore/__init__.py
@@ -153,13 +153,14 @@ def tsv_to_list(tsv):
         for i, column in enumerate(header):
             if i < len(line_cols):
                 value = line_cols[i].strip()
-                if column in DATE_COLUMNS:
-                    if value.count("/") == 2:
-                        try:
-                            dt = datetime.strptime(value, "%m/%d/%Y")
-                            value = dt.strftime("%Y-%m-%d")
-                        except ValueError:
-                            pass
+                if Context.config['convert_dates']:
+                    if column in DATE_COLUMNS:
+                        if value.count("/") == 2:
+                            try:
+                                dt = datetime.strptime(value, "%m/%d/%Y")
+                                value = dt.strftime("%Y-%m-%d")
+                            except ValueError:
+                                pass
                 line_obj[column] = value
         data.append(line_obj)
 
@@ -288,6 +289,11 @@ def main():
         catalog = discover(api)
         Context.config = args.config
         print(json.dumps(catalog, indent=2))
+
+    if args.convert_dates:
+        Context.config['convert_dates'] = True
+    else:
+        Context.config['convert_dates'] = False
 
     else:
         Context.tap_start = utils.now()

--- a/tap_appstore/__init__.py
+++ b/tap_appstore/__init__.py
@@ -284,17 +284,15 @@ def main():
         Context.config['issuer_id']
     )
 
+    if "convert_dates" not in Context.config:
+        Context.config['convert_dates'] = False
+
+
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:
         catalog = discover(api)
         Context.config = args.config
         print(json.dumps(catalog, indent=2))
-
-    if args.convert_dates:
-        Context.config['convert_dates'] = True
-    else:
-        Context.config['convert_dates'] = False
-
     else:
         Context.tap_start = utils.now()
         if args.catalog:

--- a/tap_appstore/__init__.py
+++ b/tap_appstore/__init__.py
@@ -28,6 +28,11 @@ LOGGER = singer.get_logger()
 BOOKMARK_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 TIME_EXTRACTED_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
 
+DATE_COLUMNS = {
+    "end_date", "begin_date", "event_date",
+    "original_start_date", "purchase_date"
+}
+
 API_REQUEST_FIELDS = {
     'subscription_event_report': {
         'reportType': 'SUBSCRIPTION_EVENT',
@@ -147,7 +152,15 @@ def tsv_to_list(tsv):
         line_cols = line.split('\t')
         for i, column in enumerate(header):
             if i < len(line_cols):
-                line_obj[column] = line_cols[i].strip()
+                value = line_cols[i].strip()
+                if column in DATE_COLUMNS:
+                    if value.count("/") == 2:
+                        try:
+                            dt = datetime.strptime(value, "%m/%d/%Y")
+                            value = dt.strftime("%Y-%m-%d")
+                        except ValueError:
+                            pass
+                line_obj[column] = value
         data.append(line_obj)
 
     return data


### PR DESCRIPTION
parses a few dates that might be MM/DD/YYYY and converts them to YYYY-MM-DD.

relates to https://github.com/airbytehq/airbyte/issues/23781 and should fix it if implemented as-is. no idea how much it would break existing workflows so let me know if other changes might be needed.