### PR TITLE
update version name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-appstore',
-      version='0.2.1-airbyte',
+      version='0.2.1.airbyte',
       description='Singer.io tap for extracting data from the App Store Connect API',
       author='JustEdro',
       url='https://github.com/JustEdro',


### PR DESCRIPTION
The appstore-singer source is failing to build due to a [PEP440 naming conflict](https://peps.python.org/pep-0440/) (hyphens are not recognized). Updating the version name to `0.2.1.airbyte` should resolve the issue.